### PR TITLE
Visibility and other fixes

### DIFF
--- a/exampleProject/jsdoc-results.json
+++ b/exampleProject/jsdoc-results.json
@@ -53,7 +53,8 @@
 		"description": "A simple number member",
 		"type": {
 			"names": [
-				"number"
+				"number",
+				"string"
 			]
 		},
 		"name": "myNumberMember",
@@ -89,6 +90,101 @@
 		"memberof": "myTestClass",
 		"scope": "instance",
 		"___id": "T000002R000004",
+		"___s": true
+	},
+	{
+		"comment": "/**\r\n * A class with a private members\r\n * @class\r\n */",
+		"meta": {
+			"range": [
+				56,
+				324
+			],
+			"filename": "class_privateMember.js",
+			"lineno": 5,
+			"columnno": 0,
+			"path": "C:\\Users\\maxim\\Develop\\jsdoc-tsd\\exampleProject\\src\\class",
+			"code": {
+				"id": "astnode100000020",
+				"name": "classWithPrivateMembers",
+				"type": "FunctionDeclaration",
+				"paramnames": []
+			},
+			"vars": {
+				"this.myNumberMember": "classWithPrivateMembers#myNumberMember",
+				"this.mySimpleFunction": "classWithPrivateMembers#mySimpleFunction",
+				"": null
+			}
+		},
+		"description": "A class with a private members",
+		"kind": "class",
+		"name": "classWithPrivateMembers",
+		"longname": "classWithPrivateMembers",
+		"scope": "global",
+		"params": [],
+		"___id": "T000002R000005",
+		"___s": true
+	},
+	{
+		"comment": "/**\r\n\t * A simple number member\r\n\t * @type {number|string}\r\n\t * @private\r\n\t */",
+		"meta": {
+			"range": [
+				176,
+				199
+			],
+			"filename": "class_privateMember.js",
+			"lineno": 11,
+			"columnno": 1,
+			"path": "C:\\Users\\maxim\\Develop\\jsdoc-tsd\\exampleProject\\src\\class",
+			"code": {
+				"id": "astnode100000024",
+				"name": "this.myNumberMember",
+				"type": "Literal",
+				"value": 0,
+				"paramnames": []
+			}
+		},
+		"description": "A simple number member",
+		"type": {
+			"names": [
+				"number",
+				"string"
+			]
+		},
+		"access": "private",
+		"name": "myNumberMember",
+		"longname": "classWithPrivateMembers#myNumberMember",
+		"kind": "member",
+		"memberof": "classWithPrivateMembers",
+		"scope": "instance",
+		"___id": "T000002R000006",
+		"___s": true
+	},
+	{
+		"comment": "/**\r\n\t * A simple function\r\n\t * @private\r\n\t */",
+		"meta": {
+			"range": [
+				254,
+				321
+			],
+			"filename": "class_privateMember.js",
+			"lineno": 17,
+			"columnno": 1,
+			"path": "C:\\Users\\maxim\\Develop\\jsdoc-tsd\\exampleProject\\src\\class",
+			"code": {
+				"id": "astnode100000030",
+				"name": "this.mySimpleFunction",
+				"type": "FunctionExpression",
+				"paramnames": []
+			}
+		},
+		"description": "A simple function",
+		"access": "private",
+		"name": "mySimpleFunction",
+		"longname": "classWithPrivateMembers#mySimpleFunction",
+		"kind": "function",
+		"memberof": "classWithPrivateMembers",
+		"scope": "instance",
+		"___id": "T000002R000007",
 		"___s": true
 	},
 	{

--- a/exampleProject/src/class/class_privateMember.js
+++ b/exampleProject/src/class/class_privateMember.js
@@ -1,0 +1,20 @@
+/**
+ * A class with a private members
+ * @class
+ */
+function classWithPrivateMembers() {
+	/**
+	 * A simple number member
+	 * @type {number|string}
+	 * @private
+	 */
+	this.myNumberMember = 0;
+
+	/**
+	 * A simple function
+	 * @private
+	 */
+	this.mySimpleFunction = function () {
+		// some source code...
+	}
+}

--- a/src/core/jsdoc-tsd-parser.ts
+++ b/src/core/jsdoc-tsd-parser.ts
@@ -134,15 +134,16 @@ export class JSDocTsdParser {
 
 								switch ((classMember as any).kind) {
 									case "function":
-										let functionDeclaration: any = classMember as any;
-										classMember = {
-											kind: "method",
-											name: functionDeclaration.name,
-											parameters: functionDeclaration.parameters,
-											returnType: functionDeclaration.returnType,
-											typeParameters: functionDeclaration.typeParameters
-										};
+										let functionDeclaration: dom.FunctionDeclaration = classMember as any;
+										classMember = dom.create.method(
+											functionDeclaration.name,
+											functionDeclaration.parameters,
+											functionDeclaration.returnType,
+											functionDeclaration.flags
+										);
 
+										classMember.typeParameters = functionDeclaration.typeParameters;
+										classMember.comment = functionDeclaration.comment;
 										classMember.jsDocComment = functionDeclaration.jsDocComment;
 										break;
 								}
@@ -167,14 +168,15 @@ export class JSDocTsdParser {
 								switch ((objectTypeMember as any).kind) {
 									case "function":
 										let functionDeclaration: dom.FunctionDeclaration = objectTypeMember as any;
-										objectTypeMember = {
-											kind: "method",
-											name: functionDeclaration.name,
-											parameters: functionDeclaration.parameters,
-											returnType: functionDeclaration.returnType,
-											typeParameters: functionDeclaration.typeParameters
-										};
+										objectTypeMember = dom.create.method(
+											functionDeclaration.name,
+											functionDeclaration.parameters,
+											functionDeclaration.returnType,
+											functionDeclaration.flags
+										);
 
+										objectTypeMember.typeParameters = functionDeclaration.typeParameters;
+										objectTypeMember.comment = functionDeclaration.comment;
 										objectTypeMember.jsDocComment = functionDeclaration.jsDocComment;
 										break;
 

--- a/src/core/jsdoc-tsd-parser.ts
+++ b/src/core/jsdoc-tsd-parser.ts
@@ -433,18 +433,16 @@ export class JSDocTsdParser {
 
 		if (jsdocItem.properties) {
 			for (let property of jsdocItem.properties) {
+				let propertyType: dom.Type = dom.type.any;
 				if (property.type) {
-					for (let propertyType of property.type.names) {
-						let domProperty = dom.create.property(property.name, this.mapVariableType(propertyType));
-						domProperty.jsDocComment = this.cleanJSDocComment(property.description);
-
-						if (property.optional) {
-							domProperty.flags = dom.DeclarationFlags.Optional;
-						}
-
-						domInterface.members.push(domProperty);
-					}
+					propertyType = this.mapTypesToUnion(property.type.names);
 				}
+
+				let domProperty = dom.create.property(property.name, propertyType);
+				domProperty.jsDocComment = this.cleanJSDocComment(property.comment) || property.description; // normally the property 'comment' is for these types empty
+				this.handleFlags(property, domProperty);
+
+				domInterface.members.push(domProperty);
 			}
 		}
 

--- a/src/test/class/data/class_privateMembers.json
+++ b/src/test/class/data/class_privateMembers.json
@@ -1,0 +1,106 @@
+[
+	{
+		"comment": "/**\r\n * A class with a private members\r\n * @class\r\n */",
+		"meta": {
+			"range": [
+				56,
+				324
+			],
+			"filename": "class_privateMember.js",
+			"lineno": 5,
+			"columnno": 0,
+			"path": "C:\\Users\\maxim\\Develop\\jsdoc-tsd\\exampleProject\\src\\class",
+			"code": {
+				"id": "astnode100000002",
+				"name": "classWithPrivateMembers",
+				"type": "FunctionDeclaration",
+				"paramnames": []
+			},
+			"vars": {
+				"this.myNumberMember": "classWithPrivateMembers#myNumberMember",
+				"this.mySimpleFunction": "classWithPrivateMembers#mySimpleFunction",
+				"": null
+			}
+		},
+		"description": "A class with a private members",
+		"kind": "class",
+		"name": "classWithPrivateMembers",
+		"longname": "classWithPrivateMembers",
+		"scope": "global",
+		"params": [],
+		"___id": "T000002R000002",
+		"___s": true
+	},
+	{
+		"comment": "/**\r\n\t * A simple number member\r\n\t * @type {number|string}\r\n\t * @private\r\n\t */",
+		"meta": {
+			"range": [
+				176,
+				199
+			],
+			"filename": "class_privateMember.js",
+			"lineno": 11,
+			"columnno": 1,
+			"path": "C:\\Users\\maxim\\Develop\\jsdoc-tsd\\exampleProject\\src\\class",
+			"code": {
+				"id": "astnode100000006",
+				"name": "this.myNumberMember",
+				"type": "Literal",
+				"value": 0,
+				"paramnames": []
+			}
+		},
+		"description": "A simple number member",
+		"type": {
+			"names": [
+				"number",
+				"string"
+			]
+		},
+		"access": "private",
+		"name": "myNumberMember",
+		"longname": "classWithPrivateMembers#myNumberMember",
+		"kind": "member",
+		"memberof": "classWithPrivateMembers",
+		"scope": "instance",
+		"___id": "T000002R000003",
+		"___s": true
+	},
+	{
+		"comment": "/**\r\n\t * A simple function\r\n\t * @private\r\n\t */",
+		"meta": {
+			"range": [
+				254,
+				321
+			],
+			"filename": "class_privateMember.js",
+			"lineno": 17,
+			"columnno": 1,
+			"path": "C:\\Users\\maxim\\Develop\\jsdoc-tsd\\exampleProject\\src\\class",
+			"code": {
+				"id": "astnode100000012",
+				"name": "this.mySimpleFunction",
+				"type": "FunctionExpression",
+				"paramnames": []
+			}
+		},
+		"description": "A simple function",
+		"access": "private",
+		"name": "mySimpleFunction",
+		"longname": "classWithPrivateMembers#mySimpleFunction",
+		"kind": "function",
+		"memberof": "classWithPrivateMembers",
+		"scope": "instance",
+		"___id": "T000002R000004",
+		"___s": true
+	},
+	{
+		"kind": "package",
+		"longname": "package:undefined",
+		"files": [
+			"C:\\Users\\maxim\\Develop\\jsdoc-tsd\\exampleProject\\src\\class\\class_privateMember.js"
+		],
+		"___id": "T000002R000005",
+		"___s": true
+	}
+]

--- a/src/test/class/test.parseClass.ts
+++ b/src/test/class/test.parseClass.ts
@@ -8,6 +8,7 @@ import { parse } from "querystring";
 describe("JSDocTsdParser.parse.class", () => {
 	let classData: TDoclet[] = JSON.parse(fs.readFileSync(path.resolve(__dirname, "data/class.json"), { encoding: "utf-8" }));
 	expect(classData.length).to.eq(4);
+	let classDataPrivateMembers: TDoclet[] = JSON.parse(fs.readFileSync(path.resolve(__dirname, "data/class_privateMembers.json"), { encoding: "utf-8" }));
 
 	it("should parse a class definition", () => {
 		let parser = new JSDocTsdParser();
@@ -35,5 +36,37 @@ describe("JSDocTsdParser.parse.class", () => {
 
 		let methodDeclaration: dom.MethodDeclaration = parsedClass.members[2] as dom.MethodDeclaration;
 		expect(methodDeclaration.jsDocComment).to.eq("A simple function");
+	});
+
+	it("should create a private class member", () => {
+		let parser = new JSDocTsdParser();
+		parser.parse(classDataPrivateMembers);
+		let results = parser.prepareResults();
+
+		expect(results).haveOwnPropertyDescriptor("classWithPrivateMembers");
+		let classDeclaration: dom.ClassDeclaration = results["classWithPrivateMembers"] as dom.ClassDeclaration;
+		expect(classDeclaration.members.length).to.eq(3);
+
+		let propertyDeclarations = classDeclaration.members.filter((member) => {
+			return member.kind === "property";
+		});
+		expect(propertyDeclarations.length).to.eq(1);
+		expect(propertyDeclarations[0].flags).to.eq(dom.DeclarationFlags.Private);
+	});
+
+	it("should create a private class member method", () => {
+		let parser = new JSDocTsdParser();
+		parser.parse(classDataPrivateMembers);
+		let results = parser.prepareResults();
+
+		expect(results).haveOwnPropertyDescriptor("classWithPrivateMembers");
+		let classDeclaration: dom.ClassDeclaration = results["classWithPrivateMembers"] as dom.ClassDeclaration;
+		expect(classDeclaration.members.length).to.eq(3);
+
+		let methodDeclarations = classDeclaration.members.filter((member) => {
+			return member.kind === "method";
+		});
+		expect(methodDeclarations.length).to.eq(1);
+		expect(methodDeclarations[0].flags).to.eq(dom.DeclarationFlags.Private);
 	});
 })

--- a/src/test/typedef/test.typeDefinition.ts
+++ b/src/test/typedef/test.typeDefinition.ts
@@ -26,8 +26,11 @@ describe("JSDocTsdParser.parse.typedef", () => {
 		expect(interfaceDeclarations[0].members.length).to.eq(typeData.properties.length);
 		let property: dom.PropertyDeclaration = interfaceDeclarations[0].members[0] as dom.PropertyDeclaration;
 		expect(property.name).to.eq(typeData.properties[0].name);
-		expect(property.type).to.eq(typeData.properties[0].type.names[0] as dom.Type);
 		expect(property.jsDocComment).to.eq(typeData.properties[0].description);
+
+		let unionType: dom.UnionType = property.type as dom.UnionType;
+		expect(unionType.members.length).to.eq(1);
+		expect(unionType.members[0]).to.eq(typeData.properties[0].type.names[0] as dom.Type);
 	});
 
 	it("should create an interface with an optional property", () => {

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,7 @@
 			"tabs",
 			4
 		],
-		"newline-before-return": true,
+		"newline-before-return": false,
 		"ordered-imports": true,
 		"linebreak-style": [
 			true,
@@ -36,6 +36,7 @@
 				"alphabetize": true
 			}
 		},
-		"no-console": false
+		"no-console": false,
+		"no-bitwise": false,
 	}
 }


### PR DESCRIPTION
This pull request adds visibilty/access flags to all parsed dom-elements by calling the "handleFlags" method for each parsed item.
For this reason every sub-parse function has to return the parsed jsdoc item.

The pull request also fixes the bug with the wrong property for adding the original jsdoc description