### PR TITLE
Support for since tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ $> jsdoc -d <target-dir>/<filename>.d.ts
 
 **Important: If you want to change the file name of the result file your path has to end with the file ending ```d.ts```**
 
+## Options
+* **ignoreScopes** Array with scope names which should not be parsed. Possible values
+```
+[
+    "global",
+    "inner",
+    "instance",
+    "static"
+]
+```
+* **latestVersion** If this option is passed, the since tag will be evaluated. Only elements which has the same or a smaller version will be emitted
+* **versionComparator** String representation of a function to determine if an element should be emitted or not. This function can be used if the version informations for the ```@since``` annotation is not a valid semantic versioning tag. If the function is set and the ```@since``` tag is a valid semver tag, the comparator function will be used anyway.   
+The function has to have the following signature:
+```
+/**
+ * Determines if the tagged version is less or equal the latest version
+ * @param {string} taggedVersion The value of the @since tag
+ * @param {string} [latestVersion] The configured value, if passed
+ * @returns {boolean} true, if the item should be emitted, otherwise false
+ */
+function versionComparator(taggedVersion, latestVersion) {
+
+}
+```
 ## Supported Tags
 * @enum
 * @function (implicitly)
@@ -42,6 +66,7 @@ $> jsdoc -d <target-dir>/<filename>.d.ts
 * @member
 * @ignore
 * @interface
+* @since
 
 ## Ignored Tags
 * @file

--- a/src/core/jsdoc-tsd-parser.ts
+++ b/src/core/jsdoc-tsd-parser.ts
@@ -22,12 +22,8 @@ export class JSDocTsdParser {
 		}
 
 		if (!this.config.ignoreScopes) {
-			this.config.ignoreScopes = [
-				"static",
-				"inner",
-				"global",
-				"instance"
-			];
+			this.config.ignoreScopes = [];
+		}
 
 		if (typeof this.config.versionComparator !== "string" && this.config.versionComparator !== "") {
 			this.config.versionComparator = (taggedVersion: string, latestVersion: string): boolean => {

--- a/src/test/test.since.ts
+++ b/src/test/test.since.ts
@@ -1,0 +1,148 @@
+import { expect } from "chai";
+import * as dom from "dts-dom";
+import * as fs from "fs";
+import * as path from "path";
+import { JSDocTsdParser } from "../core/jsdoc-tsd-parser";
+
+describe("Test for parsing the since tag", () => {
+	let emptyClassData = JSON.parse(fs.readFileSync(path.resolve(__dirname, "class/data/emptyClass.json"), { encoding: "utf-8" }))[0] as TDoclet;
+
+	it("should add the class definition if no since tag is set", () => {
+		let myClass: TDoclet = JSON.parse(JSON.stringify(emptyClassData));
+		myClass.since = "";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		let parser = new JSDocTsdParser();
+		parser.parse([myClass]);
+
+		let results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+
+		// The same behavior if the tag is undefined
+		myClass.since = undefined;
+		myClass.name = myClass.longname = "MyTestClass";
+
+		parser = new JSDocTsdParser();
+		parser.parse([myClass]);
+
+		results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+	});
+
+	it("should add the class definition if the tag is a valid semver tag and no latest tag is configured", () => {
+		let myClass: TDoclet = JSON.parse(JSON.stringify(emptyClassData));
+		myClass.since = "v1.0.0";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		let parser = new JSDocTsdParser();
+		parser.parse([myClass]);
+
+		let results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+
+		// same for other representation
+		myClass.since = "1.0.0";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		parser = new JSDocTsdParser();
+		parser.parse([myClass]);
+
+		results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+	});
+
+	it("should add the class definition if the tag is a valid semver tag and the latest tag is bigger than the since tag", () => {
+		let myClass: TDoclet = JSON.parse(JSON.stringify(emptyClassData));
+		myClass.since = "v1.0.0";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		let parserConfig = {
+			latestVersion: "v1.1.0"
+		};
+		let parser = new JSDocTsdParser(parserConfig);
+		parser.parse([myClass]);
+
+		let results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+
+		// same for other representation
+		myClass.since = "1.0.0";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		parser = new JSDocTsdParser(parserConfig);
+		parser.parse([myClass]);
+
+		results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+	});
+
+	it("should not add the class definition if the tag is not a valid semver tag and no custom comparator is set", () => {
+		let myClass: TDoclet = JSON.parse(JSON.stringify(emptyClassData));
+		myClass.since = "abc";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		let parser = new JSDocTsdParser();
+		parser.parse([myClass]);
+
+		let results = parser.getResultItems();
+		expect(Object.keys(results).length).to.eq(0);
+	});
+
+	it("should use the comparator function if it's passed", () => {
+		let myClass: TDoclet = JSON.parse(JSON.stringify(emptyClassData));
+		myClass.since = "abc";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		let parserConfig = {
+			versionComparator: (taggedVersion: string, latestVersion: string): boolean => {
+				return false;
+			}
+		};
+		let parser = new JSDocTsdParser(parserConfig);
+		parser.parse([myClass]);
+
+		let results = parser.getResultItems();
+		expect(Object.keys(results).length).to.eq(0);
+
+		// opposite test
+		parserConfig = {
+			versionComparator: (taggedVersion: string, latestVersion: string): boolean => {
+				return true;
+			}
+		};
+		parser = new JSDocTsdParser(parserConfig);
+		parser.parse([myClass]);
+
+		results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+	});
+
+	it("should pass the config values to the comparator function", () => {
+		let myClass: TDoclet = JSON.parse(JSON.stringify(emptyClassData));
+		myClass.since = "abc";
+		myClass.name = myClass.longname = "MyTestClass";
+
+		let parserConfig = {
+			latestVersion: "def",
+			versionComparator: (taggedVersion: string, latestVersion: string): boolean => {
+				return taggedVersion === "abc" && latestVersion === "def";
+			}
+		};
+		let parser = new JSDocTsdParser(parserConfig);
+		parser.parse([myClass]);
+		
+		let results = parser.getResultItems();
+		expect(results).haveOwnPropertyDescriptor("MyTestClass");
+		
+		// opposite test
+		parserConfig.versionComparator = (taggedVersion: string, latestVersion: string): boolean => {
+			return taggedVersion !== "abc" && latestVersion !== "def";
+		};
+		parser = new JSDocTsdParser(parserConfig);
+		parser.parse([myClass]);
+		
+		results = parser.getResultItems();
+		expect(Object.keys(results).length).to.eq(0);
+	});
+
+});

--- a/typings/jsdoc.d.ts
+++ b/typings/jsdoc.d.ts
@@ -84,6 +84,7 @@ declare interface IDocletBase {
     undocumented?: boolean;
     properties?: IDocletProp[];
     inherited?: boolean;
+    since?: string;
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for since tags. With these changes you can define a "latestVersion" property in  the jsdoc-config. If the tags are valid semantic versioning tags the module is able to compare the tags and decides if the item should be omitted or not.

Additionally you can define a custom comparator-Function to handle the since-tag by yourself.